### PR TITLE
Add configurable Pixelmon grass encounter system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # gencounters
-will trigger wild encounters trough grass
+
+A Forge server-side helper mod for Pixelmon Reforged that enables configurable wild encounters triggered by walking through grass.
+
+## Features
+
+- Uses the default `minecraft:wooden_axe` as a selection tool for defining rectangular encounter regions.
+- `/pwand` command gives moderators a pre-named wooden axe wand and clears any existing selection.
+- Selecting two corners prompts the player to configure the area with `/pencounter create <name> <minLevel> <maxLevel> <rarity>`.
+- `/pencounter` command suite to add/remove Pokémon, adjust level ranges or rarity, delete and list areas.
+- Encounter definitions are persisted to `config/gencounters/areas.json` so they survive restarts.
+- Players walking through configured grass have encounters spawned via Pixelmon's `pokespawn` command with a 1/30,000 shiny chance.
+
+## Commands
+
+| Command | Description |
+| --- | --- |
+| `/pwand` | Gives the executing player the encounter wand (wooden axe). |
+| `/pencounter create <name> <minLevel> <maxLevel> <rarity>` | Saves the current wand selection as an encounter area. Rarity should be a value between 0 and 1. |
+| `/pencounter addpokemon <name> <species> <weight>` | Adds a Pixelmon species to the named area with the supplied weight. |
+| `/pencounter removepokemon <name> <species>` | Removes a species from the named area. |
+| `/pencounter setlevels <name> <minLevel> <maxLevel>` | Updates the level range for the named area. |
+| `/pencounter setrarity <name> <rarity>` | Updates the encounter probability checked roughly once per second. |
+| `/pencounter delete <name>` | Deletes the named area. |
+| `/pencounter list` | Lists all configured encounter areas and the number of Pokémon entries configured. |
+
+## Building
+
+This project uses ForgeGradle for Minecraft 1.16.5. Install a JDK 8+ and then run:
+
+```bash
+./gradlew build
+```
+
+The compiled mod JAR will be located in `build/libs/`.

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,69 @@
+plugins {
+    id 'java'
+    id 'eclipse'
+    id 'maven-publish'
+}
+
+version = '1.0.0'
+group = 'com.gencounters'
+archivesBaseName = 'gencounters'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}
+
+repositories {
+    mavenCentral()
+    maven {
+        name = 'Forge'
+        url = 'https://maven.minecraftforge.net'
+    }
+}
+
+dependencies {
+    minecraft 'net.minecraftforge:forge:1.16.5-36.2.39'
+}
+
+minecraft {
+    mappings channel: 'official', version: '1.16.5'
+
+    runs {
+        client {
+            workingDirectory project.file('run')
+            source sourceSets.main
+        }
+        server {
+            workingDirectory project.file('run')
+            source sourceSets.main
+        }
+        data {
+            workingDirectory project.file('run')
+            args '--mod', 'gencounters', '--all', '--output', file('src/generated/resources/')
+            source sourceSets.main
+        }
+    }
+}
+
+sourceSets {
+    main {
+        resources {
+            srcDirs += 'src/generated/resources'
+        }
+    }
+}
+
+jar {
+    manifest {
+        attributes(
+                'Specification-Title': 'gencounters',
+                'Specification-Vendor': 'gencounters',
+                'Specification-Version': '1',
+                'Implementation-Title': project.name,
+                'Implementation-Version': project.version,
+                'Implementation-Vendor': 'gencounters'
+        )
+    }
+}
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,5 @@
+org.gradle.jvmargs=-Xmx3G
+minecraft_version=1.16.5
+forge_version=36.2.39
+mapping_channel=official
+mapping_version=1.16.5

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'gencounters'

--- a/src/main/java/com/gencounters/GencountersMod.java
+++ b/src/main/java/com/gencounters/GencountersMod.java
@@ -1,0 +1,47 @@
+package com.gencounters;
+
+import com.gencounters.common.command.EncounterCommand;
+import com.gencounters.common.command.WandCommand;
+import com.gencounters.common.config.EncounterStorage;
+import com.gencounters.common.encounter.EncounterRegistry;
+import com.gencounters.common.encounter.GrassEncounterHandler;
+import com.gencounters.common.selection.SelectionEventHandler;
+import com.gencounters.common.util.ModConstants;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.RegisterCommandsEvent;
+import net.minecraftforge.event.server.ServerAboutToStartEvent;
+import net.minecraftforge.event.server.ServerStoppingEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+
+@Mod(ModConstants.MOD_ID)
+public class GencountersMod {
+    public GencountersMod() {
+        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onCommonSetup);
+        MinecraftForge.EVENT_BUS.register(this);
+        MinecraftForge.EVENT_BUS.register(SelectionEventHandler.INSTANCE);
+        MinecraftForge.EVENT_BUS.register(GrassEncounterHandler.INSTANCE);
+    }
+
+    private void onCommonSetup(final FMLCommonSetupEvent event) {
+        // No-op for now but kept for future network sync or initialization.
+    }
+
+    @SubscribeEvent
+    public void onServerAboutToStart(ServerAboutToStartEvent event) {
+        EncounterStorage.load(event.getServer());
+    }
+
+    @SubscribeEvent
+    public void onServerStopping(ServerStoppingEvent event) {
+        EncounterStorage.save();
+    }
+
+    @SubscribeEvent
+    public void onRegisterCommands(RegisterCommandsEvent event) {
+        WandCommand.register(event.getDispatcher());
+        EncounterCommand.register(event.getDispatcher());
+    }
+}

--- a/src/main/java/com/gencounters/common/command/EncounterCommand.java
+++ b/src/main/java/com/gencounters/common/command/EncounterCommand.java
@@ -1,0 +1,132 @@
+package com.gencounters.common.command;
+
+import com.gencounters.common.encounter.EncounterArea;
+import com.gencounters.common.encounter.EncounterRegistry;
+import com.gencounters.common.encounter.PokemonEntry;
+import com.gencounters.common.selection.SelectionData;
+import com.gencounters.common.selection.SelectionManager;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.DoubleArgumentType;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+
+public final class EncounterCommand {
+    private static final SimpleCommandExceptionType NO_SELECTION = new SimpleCommandExceptionType(Component.translatable("command.gencounters.no_selection"));
+    private static final SimpleCommandExceptionType AREA_NOT_FOUND = new SimpleCommandExceptionType(Component.translatable("command.gencounters.area_not_found"));
+
+    private EncounterCommand() {
+    }
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(Commands.literal("pencounter")
+                .requires(source -> source.hasPermission(2))
+                .then(Commands.literal("create")
+                        .then(Commands.argument("name", StringArgumentType.word())
+                                .then(Commands.argument("minLevel", IntegerArgumentType.integer(1))
+                                        .then(Commands.argument("maxLevel", IntegerArgumentType.integer(1))
+                                                .then(Commands.argument("rarity", DoubleArgumentType.doubleArg(0.0, 1.0))
+                                                        .executes(context -> createEncounter(context, StringArgumentType.getString(context, "name"), IntegerArgumentType.getInteger(context, "minLevel"), IntegerArgumentType.getInteger(context, "maxLevel"), DoubleArgumentType.getDouble(context, "rarity"))))))))
+                .then(Commands.literal("addpokemon")
+                        .then(Commands.argument("name", StringArgumentType.word())
+                                .then(Commands.argument("species", StringArgumentType.string())
+                                        .then(Commands.argument("weight", IntegerArgumentType.integer(1))
+                                                .executes(context -> addPokemon(context, StringArgumentType.getString(context, "name"), StringArgumentType.getString(context, "species"), IntegerArgumentType.getInteger(context, "weight")))))))
+                .then(Commands.literal("removepokemon")
+                        .then(Commands.argument("name", StringArgumentType.word())
+                                .then(Commands.argument("species", StringArgumentType.string())
+                                        .executes(context -> removePokemon(context, StringArgumentType.getString(context, "name"), StringArgumentType.getString(context, "species"))))))
+                .then(Commands.literal("delete")
+                        .then(Commands.argument("name", StringArgumentType.word())
+                                .executes(context -> deleteEncounter(context, StringArgumentType.getString(context, "name")))))
+                .then(Commands.literal("list")
+                        .executes(EncounterCommand::listEncounters))
+                .then(Commands.literal("setrarity")
+                        .then(Commands.argument("name", StringArgumentType.word())
+                                .then(Commands.argument("rarity", DoubleArgumentType.doubleArg(0.0, 1.0))
+                                        .executes(context -> updateRarity(context, StringArgumentType.getString(context, "name"), DoubleArgumentType.getDouble(context, "rarity"))))))
+                .then(Commands.literal("setlevels")
+                        .then(Commands.argument("name", StringArgumentType.word())
+                                .then(Commands.argument("minLevel", IntegerArgumentType.integer(1))
+                                        .then(Commands.argument("maxLevel", IntegerArgumentType.integer(1))
+                                                .executes(context -> updateLevels(context, StringArgumentType.getString(context, "name"), IntegerArgumentType.getInteger(context, "minLevel"), IntegerArgumentType.getInteger(context, "maxLevel"))))))));
+    }
+
+    private static int createEncounter(CommandContext<CommandSourceStack> context, String name, int minLevel, int maxLevel, double rarity) throws CommandSyntaxException {
+        ServerPlayer player = context.getSource().getPlayerOrException();
+        SelectionData selection = SelectionManager.getSelection(player);
+        if (selection == null || !selection.isComplete()) {
+            throw NO_SELECTION.create();
+        }
+        BlockPos first = selection.getFirst();
+        BlockPos second = selection.getSecond();
+        EncounterArea area = new EncounterArea(name, first, second, minLevel, maxLevel, rarity);
+        EncounterRegistry.addArea(area);
+        SelectionManager.clearSelection(player);
+        player.sendSystemMessage(Component.translatable("message.gencounters.area.created", name));
+        return 1;
+    }
+
+    private static int addPokemon(CommandContext<CommandSourceStack> context, String name, String species, int weight) throws CommandSyntaxException {
+        EncounterArea area = EncounterRegistry.getArea(name).orElseThrow(AREA_NOT_FOUND::create);
+        area.getPokemonEntries().add(new PokemonEntry(species, weight));
+        context.getSource().sendSuccess(() -> Component.translatable("message.gencounters.area.pokemon_added", species, name), true);
+        EncounterRegistry.addArea(area);
+        return 1;
+    }
+
+    private static int removePokemon(CommandContext<CommandSourceStack> context, String name, String species) throws CommandSyntaxException {
+        EncounterArea area = EncounterRegistry.getArea(name).orElseThrow(AREA_NOT_FOUND::create);
+        boolean removed = area.getPokemonEntries().removeIf(entry -> entry.getSpecies().equalsIgnoreCase(species));
+        if (removed) {
+            context.getSource().sendSuccess(() -> Component.translatable("message.gencounters.area.pokemon_removed", species, name), true);
+            EncounterRegistry.addArea(area);
+        } else {
+            context.getSource().sendFailure(Component.translatable("message.gencounters.area.pokemon_missing", species, name));
+        }
+        return removed ? 1 : 0;
+    }
+
+    private static int deleteEncounter(CommandContext<CommandSourceStack> context, String name) {
+        if (EncounterRegistry.getArea(name).isEmpty()) {
+            context.getSource().sendFailure(Component.translatable("message.gencounters.area_not_found"));
+            return 0;
+        }
+        EncounterRegistry.removeArea(name);
+        context.getSource().sendSuccess(() -> Component.translatable("message.gencounters.area.deleted", name), true);
+        return 1;
+    }
+
+    private static int listEncounters(CommandContext<CommandSourceStack> context) {
+        if (EncounterRegistry.getAreas().isEmpty()) {
+            context.getSource().sendSuccess(() -> Component.translatable("message.gencounters.area.none"), false);
+            return 0;
+        }
+        EncounterRegistry.getAreas().forEach(area -> context.getSource().sendSuccess(() -> Component.translatable("message.gencounters.area.entry", area.getName(), area.getMinLevel(), area.getMaxLevel(), area.getRarity(), area.getPokemonEntries().size()), false));
+        return 1;
+    }
+
+    private static int updateRarity(CommandContext<CommandSourceStack> context, String name, double rarity) throws CommandSyntaxException {
+        EncounterArea area = EncounterRegistry.getArea(name).orElseThrow(AREA_NOT_FOUND::create);
+        area.setRarity(rarity);
+        EncounterRegistry.addArea(area);
+        context.getSource().sendSuccess(() -> Component.translatable("message.gencounters.area.rarity", name, rarity), true);
+        return 1;
+    }
+
+    private static int updateLevels(CommandContext<CommandSourceStack> context, String name, int minLevel, int maxLevel) throws CommandSyntaxException {
+        EncounterArea area = EncounterRegistry.getArea(name).orElseThrow(AREA_NOT_FOUND::create);
+        area.setMinLevel(minLevel);
+        area.setMaxLevel(maxLevel);
+        EncounterRegistry.addArea(area);
+        context.getSource().sendSuccess(() -> Component.translatable("message.gencounters.area.levels", name, minLevel, maxLevel), true);
+        return 1;
+    }
+}

--- a/src/main/java/com/gencounters/common/command/WandCommand.java
+++ b/src/main/java/com/gencounters/common/command/WandCommand.java
@@ -1,0 +1,35 @@
+package com.gencounters.common.command;
+
+import com.gencounters.common.selection.SelectionManager;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+
+public final class WandCommand {
+    private WandCommand() {
+    }
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(Commands.literal("pwand")
+                .requires(source -> source.hasPermission(2))
+                .executes(context -> giveWand(context.getSource())));
+    }
+
+    private static int giveWand(CommandSourceStack source) throws CommandSyntaxException {
+        ServerPlayer player = source.getPlayerOrException();
+        ItemStack wand = new ItemStack(Items.WOODEN_AXE);
+        wand.setHoverName(Component.translatable("item.gencounters.selection_wand"));
+        boolean added = player.getInventory().add(wand);
+        if (!added) {
+            player.drop(wand, false);
+        }
+        player.sendSystemMessage(Component.translatable("message.gencounters.wand.given"));
+        SelectionManager.clearSelection(player);
+        return 1;
+    }
+}

--- a/src/main/java/com/gencounters/common/config/EncounterStorage.java
+++ b/src/main/java/com/gencounters/common/config/EncounterStorage.java
@@ -1,0 +1,70 @@
+package com.gencounters.common.config;
+
+import com.gencounters.common.encounter.EncounterArea;
+import com.gencounters.common.encounter.EncounterRegistry;
+import com.gencounters.common.util.ModConstants;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import net.minecraft.server.MinecraftServer;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.lang.reflect.Type;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public final class EncounterStorage {
+    private static final Gson GSON = new GsonBuilder()
+            .setPrettyPrinting()
+            .registerTypeAdapter(EncounterArea.class, new EncounterTypeAdapter())
+            .create();
+    private static final Type COLLECTION_TYPE = new TypeToken<List<EncounterArea>>() {
+    }.getType();
+    private static Path storagePath;
+
+    private EncounterStorage() {
+    }
+
+    public static void load(MinecraftServer server) {
+        Path basePath = server.getServerDirectory().toPath().resolve("config");
+        storagePath = basePath.resolve(ModConstants.MOD_ID).resolve("areas.json");
+        try {
+            Files.createDirectories(storagePath.getParent());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create config directory", e);
+        }
+
+        if (!Files.exists(storagePath)) {
+            EncounterRegistry.replaceAll(new ArrayList<>());
+            save();
+            return;
+        }
+
+        try (Reader reader = Files.newBufferedReader(storagePath)) {
+            List<EncounterArea> areas = GSON.fromJson(reader, COLLECTION_TYPE);
+            if (areas == null) {
+                areas = new ArrayList<>();
+            }
+            EncounterRegistry.replaceAll(areas);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read encounter storage", e);
+        }
+    }
+
+    public static void save() {
+        if (storagePath == null) {
+            return;
+        }
+        Collection<EncounterArea> areas = EncounterRegistry.getAreas();
+        try (Writer writer = Files.newBufferedWriter(storagePath)) {
+            GSON.toJson(areas, COLLECTION_TYPE, writer);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to save encounter storage", e);
+        }
+    }
+}

--- a/src/main/java/com/gencounters/common/config/EncounterTypeAdapter.java
+++ b/src/main/java/com/gencounters/common/config/EncounterTypeAdapter.java
@@ -1,0 +1,63 @@
+package com.gencounters.common.config;
+
+import com.gencounters.common.encounter.EncounterArea;
+import com.gencounters.common.encounter.PokemonEntry;
+import com.google.gson.*;
+import net.minecraft.core.BlockPos;
+
+import java.lang.reflect.Type;
+
+public class EncounterTypeAdapter implements JsonSerializer<EncounterArea>, JsonDeserializer<EncounterArea> {
+    @Override
+    public EncounterArea deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+        JsonObject object = json.getAsJsonObject();
+        EncounterArea area = new EncounterArea();
+        area.setName(object.get("name").getAsString());
+        area.setFirstCorner(deserializeBlockPos(object.getAsJsonObject("first")));
+        area.setSecondCorner(deserializeBlockPos(object.getAsJsonObject("second")));
+        area.setMinLevel(object.get("minLevel").getAsInt());
+        area.setMaxLevel(object.get("maxLevel").getAsInt());
+        area.setRarity(object.get("rarity").getAsDouble());
+        JsonArray entries = object.getAsJsonArray("entries");
+        if (entries != null) {
+            for (JsonElement element : entries) {
+                area.getPokemonEntries().add(context.deserialize(element, PokemonEntry.class));
+            }
+        }
+        return area;
+    }
+
+    @Override
+    public JsonElement serialize(EncounterArea src, Type typeOfSrc, JsonSerializationContext context) {
+        JsonObject object = new JsonObject();
+        object.addProperty("name", src.getName());
+        object.add("first", serializeBlockPos(src.getFirstCorner()));
+        object.add("second", serializeBlockPos(src.getSecondCorner()));
+        object.addProperty("minLevel", src.getMinLevel());
+        object.addProperty("maxLevel", src.getMaxLevel());
+        object.addProperty("rarity", src.getRarity());
+        JsonArray entries = new JsonArray();
+        for (PokemonEntry entry : src.getPokemonEntries()) {
+            entries.add(context.serialize(entry, PokemonEntry.class));
+        }
+        object.add("entries", entries);
+        return object;
+    }
+
+    private JsonObject serializeBlockPos(BlockPos pos) {
+        JsonObject object = new JsonObject();
+        if (pos != null) {
+            object.addProperty("x", pos.getX());
+            object.addProperty("y", pos.getY());
+            object.addProperty("z", pos.getZ());
+        }
+        return object;
+    }
+
+    private BlockPos deserializeBlockPos(JsonObject object) {
+        if (object == null || !object.has("x") || !object.has("y") || !object.has("z")) {
+            return null;
+        }
+        return new BlockPos(object.get("x").getAsInt(), object.get("y").getAsInt(), object.get("z").getAsInt());
+    }
+}

--- a/src/main/java/com/gencounters/common/encounter/EncounterArea.java
+++ b/src/main/java/com/gencounters/common/encounter/EncounterArea.java
@@ -1,0 +1,123 @@
+package com.gencounters.common.encounter;
+
+import net.minecraft.core.BlockPos;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+public class EncounterArea {
+    private String name;
+    private BlockPos firstCorner;
+    private BlockPos secondCorner;
+    private int minLevel;
+    private int maxLevel;
+    private double rarity;
+    private final List<PokemonEntry> pokemonEntries = new ArrayList<>();
+
+    public EncounterArea() {
+    }
+
+    public EncounterArea(String name, BlockPos firstCorner, BlockPos secondCorner, int minLevel, int maxLevel, double rarity) {
+        this.name = name;
+        setFirstCorner(firstCorner);
+        setSecondCorner(secondCorner);
+        setMinLevel(Math.min(minLevel, maxLevel));
+        setMaxLevel(Math.max(minLevel, maxLevel));
+        this.rarity = clampRarity(rarity);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public BlockPos getFirstCorner() {
+        return firstCorner;
+    }
+
+    public void setFirstCorner(BlockPos firstCorner) {
+        this.firstCorner = firstCorner == null ? null : firstCorner.immutable();
+    }
+
+    public BlockPos getSecondCorner() {
+        return secondCorner;
+    }
+
+    public void setSecondCorner(BlockPos secondCorner) {
+        this.secondCorner = secondCorner == null ? null : secondCorner.immutable();
+    }
+
+    public int getMinLevel() {
+        return minLevel;
+    }
+
+    public void setMinLevel(int minLevel) {
+        this.minLevel = Math.max(1, minLevel);
+    }
+
+    public int getMaxLevel() {
+        return maxLevel;
+    }
+
+    public void setMaxLevel(int maxLevel) {
+        this.maxLevel = Math.max(this.minLevel, maxLevel);
+    }
+
+    public double getRarity() {
+        return rarity;
+    }
+
+    public void setRarity(double rarity) {
+        this.rarity = clampRarity(rarity);
+    }
+
+    public List<PokemonEntry> getPokemonEntries() {
+        return pokemonEntries;
+    }
+
+    private double clampRarity(double value) {
+        return Math.max(0.0D, Math.min(1.0D, value));
+    }
+
+    public boolean contains(BlockPos pos) {
+        if (firstCorner == null || secondCorner == null) {
+            return false;
+        }
+        int minX = Math.min(firstCorner.getX(), secondCorner.getX());
+        int maxX = Math.max(firstCorner.getX(), secondCorner.getX());
+        int minY = Math.min(firstCorner.getY(), secondCorner.getY());
+        int maxY = Math.max(firstCorner.getY(), secondCorner.getY());
+        int minZ = Math.min(firstCorner.getZ(), secondCorner.getZ());
+        int maxZ = Math.max(firstCorner.getZ(), secondCorner.getZ());
+        return pos.getX() >= minX && pos.getX() <= maxX
+                && pos.getY() >= minY && pos.getY() <= maxY
+                && pos.getZ() >= minZ && pos.getZ() <= maxZ;
+    }
+
+    public int pickLevel(Random random) {
+        if (minLevel >= maxLevel) {
+            return Math.max(1, minLevel);
+        }
+        return minLevel + random.nextInt(maxLevel - minLevel + 1);
+    }
+
+    public PokemonEntry pickRandomEntry(Random random) {
+        if (pokemonEntries.isEmpty()) {
+            return null;
+        }
+        int totalWeight = pokemonEntries.stream().mapToInt(PokemonEntry::getWeight).sum();
+        int choice = random.nextInt(Math.max(totalWeight, 1));
+        int current = 0;
+        for (PokemonEntry entry : pokemonEntries) {
+            current += Math.max(1, entry.getWeight());
+            if (choice < current) {
+                return entry;
+            }
+        }
+        return pokemonEntries.get(pokemonEntries.size() - 1);
+    }
+}

--- a/src/main/java/com/gencounters/common/encounter/EncounterRegistry.java
+++ b/src/main/java/com/gencounters/common/encounter/EncounterRegistry.java
@@ -1,0 +1,51 @@
+package com.gencounters.common.encounter;
+
+import com.gencounters.common.config.EncounterStorage;
+import net.minecraft.core.BlockPos;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class EncounterRegistry {
+    private static final Map<String, EncounterArea> AREAS = new ConcurrentHashMap<>();
+
+    private EncounterRegistry() {
+    }
+
+    public static Collection<EncounterArea> getAreas() {
+        return Collections.unmodifiableCollection(AREAS.values());
+    }
+
+    public static void replaceAll(Collection<EncounterArea> areas) {
+        AREAS.clear();
+        areas.forEach(area -> AREAS.put(area.getName().toLowerCase(), area));
+    }
+
+    public static void addArea(EncounterArea area) {
+        AREAS.put(area.getName().toLowerCase(), area);
+        EncounterStorage.save();
+    }
+
+    public static void removeArea(String name) {
+        AREAS.remove(name.toLowerCase());
+        EncounterStorage.save();
+    }
+
+    public static Optional<EncounterArea> getArea(String name) {
+        return Optional.ofNullable(AREAS.get(name.toLowerCase()));
+    }
+
+    @Nullable
+    public static EncounterArea findAreaFor(BlockPos pos) {
+        for (EncounterArea area : AREAS.values()) {
+            if (area.contains(pos)) {
+                return area;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/gencounters/common/encounter/GrassEncounterHandler.java
+++ b/src/main/java/com/gencounters/common/encounter/GrassEncounterHandler.java
@@ -1,0 +1,98 @@
+package com.gencounters.common.encounter;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.BushBlock;
+import net.minecraft.world.level.block.GrassBlock;
+import net.minecraft.world.level.block.TallGrassBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+
+public final class GrassEncounterHandler {
+    public static final GrassEncounterHandler INSTANCE = new GrassEncounterHandler();
+    private static final int COOLDOWN_TICKS = 200;
+    private final Map<UUID, Integer> cooldowns = new HashMap<>();
+    private final Random random = new Random();
+
+    private GrassEncounterHandler() {
+    }
+
+    @SubscribeEvent
+    public void onPlayerTick(TickEvent.PlayerTickEvent event) {
+        if (event.phase != TickEvent.Phase.END) {
+            return;
+        }
+        if (!(event.player instanceof ServerPlayer player)) {
+            return;
+        }
+        UUID uuid = player.getUUID();
+        cooldowns.computeIfPresent(uuid, (id, ticks) -> ticks - 1 <= 0 ? null : ticks - 1);
+        if (cooldowns.containsKey(uuid)) {
+            return;
+        }
+        if (player.tickCount % 20 != 0) {
+            return;
+        }
+        if (!isInGrass(player)) {
+            return;
+        }
+        EncounterArea area = EncounterRegistry.findAreaFor(player.blockPosition());
+        if (area == null) {
+            return;
+        }
+        if (random.nextDouble() > area.getRarity()) {
+            return;
+        }
+        PokemonEntry entry = area.pickRandomEntry(random);
+        if (entry == null) {
+            return;
+        }
+        triggerEncounter(player, area, entry);
+    }
+
+    private boolean isInGrass(ServerPlayer player) {
+        BlockPos pos = player.blockPosition();
+        ServerLevel level = player.serverLevel();
+        BlockState stateAtFeet = level.getBlockState(pos);
+        BlockState stateBelow = level.getBlockState(pos.below());
+        return isGrassBlock(stateAtFeet) || isGrassBlock(stateBelow);
+    }
+
+    private boolean isGrassBlock(BlockState state) {
+        Block block = state.getBlock();
+        return block instanceof TallGrassBlock || block instanceof BushBlock || block instanceof GrassBlock
+                || block == Blocks.GRASS || block == Blocks.FERN || block == Blocks.TALL_GRASS || block == Blocks.LARGE_FERN
+                || block == Blocks.GRASS_BLOCK;
+    }
+
+    private void triggerEncounter(ServerPlayer player, EncounterArea area, PokemonEntry entry) {
+        MinecraftServer server = player.server;
+        if (server == null) {
+            return;
+        }
+        if (entry.getSpecies() == null || entry.getSpecies().isEmpty()) {
+            return;
+        }
+        cooldowns.put(player.getUUID(), COOLDOWN_TICKS);
+        int level = area.pickLevel(random);
+        boolean shiny = random.nextInt(30000) == 0;
+        StringBuilder command = new StringBuilder("pokespawn ").append(entry.getSpecies())
+                .append(" lvl:").append(level);
+        if (shiny) {
+            command.append(" shiny");
+        }
+        server.getCommands().performPrefixedCommand(player.createCommandSourceStack().withSuppressedOutput().withPermission(4), command.toString());
+        player.sendSystemMessage(Component.translatable("message.gencounters.encounter.trigger", entry.getSpecies(), level, shiny));
+    }
+}

--- a/src/main/java/com/gencounters/common/encounter/PokemonEntry.java
+++ b/src/main/java/com/gencounters/common/encounter/PokemonEntry.java
@@ -1,0 +1,30 @@
+package com.gencounters.common.encounter;
+
+public class PokemonEntry {
+    private String species;
+    private int weight;
+
+    public PokemonEntry() {
+    }
+
+    public PokemonEntry(String species, int weight) {
+        this.species = species;
+        this.weight = Math.max(1, weight);
+    }
+
+    public String getSpecies() {
+        return species;
+    }
+
+    public void setSpecies(String species) {
+        this.species = species;
+    }
+
+    public int getWeight() {
+        return weight;
+    }
+
+    public void setWeight(int weight) {
+        this.weight = Math.max(1, weight);
+    }
+}

--- a/src/main/java/com/gencounters/common/selection/SelectionData.java
+++ b/src/main/java/com/gencounters/common/selection/SelectionData.java
@@ -1,0 +1,37 @@
+package com.gencounters.common.selection;
+
+import net.minecraft.core.BlockPos;
+
+import javax.annotation.Nullable;
+
+public class SelectionData {
+    private BlockPos firstPos;
+    private BlockPos secondPos;
+
+    public void setFirst(BlockPos pos) {
+        this.firstPos = pos;
+    }
+
+    public void setSecond(BlockPos pos) {
+        this.secondPos = pos;
+    }
+
+    @Nullable
+    public BlockPos getFirst() {
+        return firstPos;
+    }
+
+    @Nullable
+    public BlockPos getSecond() {
+        return secondPos;
+    }
+
+    public boolean isComplete() {
+        return firstPos != null && secondPos != null;
+    }
+
+    public void reset() {
+        firstPos = null;
+        secondPos = null;
+    }
+}

--- a/src/main/java/com/gencounters/common/selection/SelectionEventHandler.java
+++ b/src/main/java/com/gencounters/common/selection/SelectionEventHandler.java
@@ -1,0 +1,45 @@
+package com.gencounters.common.selection;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+public final class SelectionEventHandler {
+    public static final SelectionEventHandler INSTANCE = new SelectionEventHandler();
+
+    private SelectionEventHandler() {
+    }
+
+    @SubscribeEvent
+    public void onLeftClick(PlayerInteractEvent.LeftClickBlock event) {
+        if (!(event.getPlayer() instanceof ServerPlayer player)) {
+            return;
+        }
+        if (!SelectionManager.isSelectionTool(event.getItemStack())) {
+            return;
+        }
+        BlockPos pos = event.getPos();
+        SelectionManager.setFirst(player, pos);
+        event.setCanceled(true);
+    }
+
+    @SubscribeEvent
+    public void onRightClick(PlayerInteractEvent.RightClickBlock event) {
+        if (!(event.getPlayer() instanceof ServerPlayer player)) {
+            return;
+        }
+        if (!SelectionManager.isSelectionTool(event.getItemStack())) {
+            return;
+        }
+        if (event.getHand() != InteractionHand.MAIN_HAND) {
+            return;
+        }
+        BlockPos pos = event.getPos();
+        SelectionManager.setSecond(player, pos);
+        event.setCanceled(true);
+        event.setCancellationResult(InteractionResult.SUCCESS);
+    }
+}

--- a/src/main/java/com/gencounters/common/selection/SelectionManager.java
+++ b/src/main/java/com/gencounters/common/selection/SelectionManager.java
@@ -1,0 +1,60 @@
+package com.gencounters.common.selection;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.network.chat.Component;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class SelectionManager {
+    private static final Map<UUID, SelectionData> ACTIVE_SELECTIONS = new ConcurrentHashMap<>();
+
+    private SelectionManager() {
+    }
+
+    public static boolean isSelectionTool(ItemStack stack) {
+        return !stack.isEmpty() && stack.getItem() == Items.WOODEN_AXE;
+    }
+
+    private static SelectionData getOrCreate(ServerPlayer player) {
+        return ACTIVE_SELECTIONS.computeIfAbsent(player.getUUID(), uuid -> new SelectionData());
+    }
+
+    public static void setFirst(ServerPlayer player, BlockPos pos) {
+        SelectionData selection = getOrCreate(player);
+        selection.setFirst(pos.immutable());
+        player.sendSystemMessage(Component.translatable("message.gencounters.selection.first", pos.getX(), pos.getY(), pos.getZ()));
+        if (selection.getSecond() != null) {
+            promptForEncounter(player);
+        }
+    }
+
+    public static void setSecond(ServerPlayer player, BlockPos pos) {
+        SelectionData selection = getOrCreate(player);
+        selection.setSecond(pos.immutable());
+        player.sendSystemMessage(Component.translatable("message.gencounters.selection.second", pos.getX(), pos.getY(), pos.getZ()));
+        if (selection.getFirst() != null) {
+            promptForEncounter(player);
+        }
+    }
+
+    public static SelectionData getSelection(ServerPlayer player) {
+        return getOrCreate(player);
+    }
+
+    public static void clearSelection(ServerPlayer player) {
+        ACTIVE_SELECTIONS.remove(player.getUUID());
+    }
+
+    private static void promptForEncounter(ServerPlayer player) {
+        SelectionData selection = getOrCreate(player);
+        if (!selection.isComplete()) {
+            return;
+        }
+        player.sendSystemMessage(Component.translatable("message.gencounters.selection.prompt"));
+    }
+}

--- a/src/main/java/com/gencounters/common/util/ModConstants.java
+++ b/src/main/java/com/gencounters/common/util/ModConstants.java
@@ -1,0 +1,8 @@
+package com.gencounters.common.util;
+
+public final class ModConstants {
+    public static final String MOD_ID = "gencounters";
+
+    private ModConstants() {
+    }
+}

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,0 +1,16 @@
+modLoader="javafml"
+loaderVersion="[36,)"
+license="MIT"
+issueTrackerURL=""
+[[mods]]
+modId="gencounters"
+version="1.0.0"
+displayName="Grass Encounters"
+updateJSONURL=""
+displayURL=""
+logoFile=""
+credits=""
+authors="Server Automation"
+description='''
+Adds configurable Pixelmon encounters triggered by grass.
+'''

--- a/src/main/resources/assets/gencounters/lang/en_us.json
+++ b/src/main/resources/assets/gencounters/lang/en_us.json
@@ -1,0 +1,20 @@
+{
+  "item.gencounters.selection_wand": "Pixelmon Encounter Wand",
+  "message.gencounters.wand.given": "You feel attuned to the grass around you.",
+  "message.gencounters.selection.first": "First position set to %s, %s, %s.",
+  "message.gencounters.selection.second": "Second position set to %s, %s, %s.",
+  "message.gencounters.selection.prompt": "Use /pencounter create <name> <minLevel> <maxLevel> <rarity> to store this region.",
+  "message.gencounters.area.created": "Encounter area '%s' saved.",
+  "message.gencounters.area.pokemon_added": "Added %s to area %s.",
+  "message.gencounters.area.pokemon_removed": "Removed %s from area %s.",
+  "message.gencounters.area.pokemon_missing": "%s is not configured for area %s.",
+  "message.gencounters.area.deleted": "Deleted encounter area %s.",
+  "message.gencounters.area.none": "No encounter areas are configured.",
+  "message.gencounters.area.entry": "Area %s (Lv.%s-%s) rarity %.2f with %s Pokémon options.",
+  "message.gencounters.area.rarity": "Updated rarity for %s to %.2f.",
+  "message.gencounters.area.levels": "Updated level range for %s to %s-%s.",
+  "message.gencounters.encounter.trigger": "A wild %s (Lv.%s) appeared! Shiny: %s",
+  "message.gencounters.area_not_found": "That encounter area could not be found.",
+  "command.gencounters.no_selection": "Select two corners with the wand before creating an encounter area.",
+  "command.gencounters.area_not_found": "No encounter area exists by that name."
+}

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "description": "Grass Encounters resources",
+    "pack_format": 6
+  }
+}


### PR DESCRIPTION
## Summary
- add a Forge mod entry point that loads encounter data, registers commands, and hooks custom selection and encounter handlers
- implement wooden-axe selection tools, persistent encounter area storage, and commands for defining Pixelmon spawn pools
- trigger grass encounters with a configurable rarity and a 1-in-30,000 shiny roll, plus localization and documentation updates

## Testing
- not run (build tooling not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68cad1db93ac8330a608552b5176d848